### PR TITLE
Managing via systemd

### DIFF
--- a/scripts/reg_systemd_unit.sh
+++ b/scripts/reg_systemd_unit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+cat <<EOLONGFILE > /etc/systemd/system/tonnode.service
+[Unit]
+Description=TON Node service
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$SCRIPT_DIR
+ExecStartPre=$SCRIPT_DIR/env.sh && exit 0
+ExecStart=$SCRIPT_DIR/run.sh
+RemainAfterExit=yes
+StandardOutput=syslog
+StandardError=syslog
+User=$(whoami)
+Group=$(whoami)
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOLONGFILE
+
+systemctl daemon-reload
+
+echo 'DONE'
+echo ''
+echo 'Use "service tonnode start" for start node'
+echo 'Use "systemctl enable tonnode" for add to startup'

--- a/scripts/unreg_systemd_unit.sh
+++ b/scripts/unreg_systemd_unit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+service tonnode stop > /dev/null 2>&1
+systemctl disable tonnode > /dev/null 2>&1
+rm /etc/systemd/system/tonnode.service > /dev/null 2>&1
+echo 'DONE'


### PR DESCRIPTION
For convenience, I made 2 scripts for managing the node for systemd: for registration and deletion.
As a result you will be able to launch the node via `service tonnode start` and add it to startup `systemctl enable tonnode`